### PR TITLE
Fix getting Windows default network interface

### DIFF
--- a/src/NetworkManager.ts
+++ b/src/NetworkManager.ts
@@ -414,6 +414,7 @@ export class NetworkManager extends EventEmitter {
   }
 
   private static readonly WIN_CHAR_PATTERN = /[a-zA-Z]/;
+  private static readonly WIN_DEFAULT_IP_PATTERN = /0\.0\.0\.0[ ]+0\.0\.0\.0/;
   private static getWinDefaultNetworkInterface(): Promise<InterfaceName> {
     return new Promise((resolve, reject) => {
       const command = "netstat -r";
@@ -426,8 +427,8 @@ export class NetworkManager extends EventEmitter {
         let defaultIp;
         const lines = stdout.split(os.EOL);
         for (const line of lines) {
-          if (line.indexOf("0.0.0.0 0.0.0.0") > -1 && !(this.WIN_CHAR_PATTERN.test(line))) {
-            const parts = line.split(" ");
+          if (this.WIN_DEFAULT_IP_PATTERN.test(line) && !(this.WIN_CHAR_PATTERN.test(line))) {
+            const parts = line.split(/[ ]+/);
             if (parts.length >= 5) {
               defaultIp = parts[parts.length - 2];
             }


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/7399140/88841274-8e3cc880-d192-11ea-96b8-4b8d4cb35fea.png)

This was because the search after running `netstat -r` only expected 1 space inbetween data. In my case, there were multiple spaces.
![image](https://user-images.githubusercontent.com/7399140/88841334-ad3b5a80-d192-11ea-80e9-9c1a8748b641.png)

I modified the windows section to check for 1 space or more.
After
![image](https://user-images.githubusercontent.com/7399140/88841651-17ec9600-d193-11ea-977e-b061af5279a3.png)
