### PR TITLE
NetworkManager should use correct field offset on SunOS and friends

### DIFF
--- a/src/NetworkManager.ts
+++ b/src/NetworkManager.ts
@@ -754,11 +754,12 @@ export class NetworkManager extends EventEmitter {
           return;
         }
 
+        const interfaceArrayOffset = os.platform() === "sunos" ? 0 : 2;
         const lines = stdout.split(os.EOL);
         const names: InterfaceName[] = [];
 
         for (let i = 1; i < lines.length - 1; i++) {
-          const interfaceName = lines[i].trim().split(NetworkManager.SPACE_PATTERN)[2];
+          const interfaceName = lines[i].trim().split(NetworkManager.SPACE_PATTERN)[interfaceArrayOffset];
           if (!interfaceName) {
             debug(`${os.platform()}: Failed to read interface name from line ${i}: '${lines[i]}'`);
             continue;


### PR DESCRIPTION
## :recycle: Current situation

See #21, but basically the field offset in the `arp` command output on SunOS-like systems does not match 100% with OpenBSD systems, resulting in `NetworkManager.getOpenBSD_SUNOS_NetworkInterfaces()` not returning any interfaces on SunOS-like systems. Making CIAO kind of useless.

## :bulb: Proposed solution

Overall the code in `NetworkManager.getOpenBSD_SUNOS_NetworkInterfaces()`  looks good, it just needs a different field offset between OpenBSD and SunOS.

When `os.platform()` returns sunos (which it does on Oracle Solaris **and** illumos distros (OpenSolaris continuation)), we simple use a different offset. The default is left as 2 which was the old value.

## :gear: Release Notes

CIAO now works properly on SunOS-like systems and will be able to listen on an interface that is not lo0.

## :heavy_plus_sign: Additional Information
n/a

### Testing

Made sure I could run `npm run test` and that the tests still pass
```
[hyperon :: sjorge][/tmp/ciao][sunos ✔]
[■]$ npm run test

> @homebridge/ciao@1.1.3 test
> jest

 PASS  src/util/sorted-array.spec.ts (5.396 s)
 PASS  src/util/dns-equal.spec.ts (5.327 s)
 PASS  src/coder/DNSLabelCoder.spec.ts (5.845 s)
 PASS  src/util/domain-formatter.spec.ts (5.926 s)
 PASS  src/NetworkManager.spec.ts (6.112 s)
 PASS  src/util/tiebreaking.spec.ts (6.27 s)
 PASS  src/coder/Question.spec.ts (6.225 s)
 PASS  src/MDNSServer.spec.ts (6.32 s)
 PASS  src/coder/DNSPacket.spec.ts (6.473 s)
 PASS  src/coder/ResourceRecord.spec.ts (6.468 s)
 PASS  src/responder/TruncatedQuery.spec.ts (7.016 s)
```

I also switched my nrchkb node-red setup over to the CIAO backend instead of older bonjour backend. (Wanting to switch is what made me discover CIAO was broken)

I've been running said setup for about a month now with CIAO and the change in this PR.

### Reviewer Nudging

Not sure, it's a simple offset change, the original issue I filed lists the output of the execute arp command for an illumos based distro and from Oracle Solaris.