### PR TITLE
Fix TXT record encoding

### DIFF
--- a/src/coder/records/TXTRecord.ts
+++ b/src/coder/records/TXTRecord.ts
@@ -19,7 +19,7 @@ export class TXTRecord extends ResourceRecord {
       super(name);
     }
 
-    this.txt = txt;
+    this.txt = txt.length === 0 ? [Buffer.from([])] : txt;
   }
 
   protected getRDataEncodingLength(): number {


### PR DESCRIPTION
## :recycle: Current situation

When the advertised service has no TXT data, the RDATA generated is invalid. RFC 1035 3.3.14. mandates TXT RDATA be "One or more &lt;character-string&gt;s". Currently ciao generates zero &lt;character-string&gt;s if there is no TXT data associated with the service.

In this case other server implementations seem to return a TXT RDATA containing one &lt;character-string&gt; of zero length which is valid according to the RFC.

Most client implementations gracefully handle the invalid data. iOS 17 does not, so currently services advertised by ciao are not discoverable on iOS 17.

## :bulb: Proposed solution

Follow other server implementations' behavior: return one &lt;character-string&gt; having length of 0. `this.txt` is assigned accordingly in `TXTRecord` constructor.

## :gear: Release Notes

Fix TXT record encoding according to RFC 1035.

### Testing

No changes.

### Reviewer Nudging

Oneliner! ;)