### PR TITLE
Replace fast-deep-equal with Node.js built-in

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.5",
-        "fast-deep-equal": "^3.1.3",
         "source-map-support": "^0.5.21",
         "tslib": "^2.6.3"
       },
@@ -2879,6 +2878,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
   ],
   "dependencies": {
     "debug": "^4.3.5",
-    "fast-deep-equal": "^3.1.3",
     "source-map-support": "^0.5.21",
     "tslib": "^2.6.3"
   },

--- a/src/NetworkManager.ts
+++ b/src/NetworkManager.ts
@@ -3,7 +3,7 @@ import assert from "assert";
 import childProcess from "child_process";
 import createDebug from "debug";
 import { EventEmitter } from "events";
-import deepEqual from "fast-deep-equal";
+import {isDeepStrictEqual as deepEqual} from "util";
 import net from "net";
 import os, { NetworkInterfaceInfo } from "os";
 import { getNetAddress } from "./util/domain-formatter";

--- a/src/coder/DNSPacket.ts
+++ b/src/coder/DNSPacket.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import deepEqual from "fast-deep-equal";
+import {isDeepStrictEqual as deepEqual} from "util";
 import { AddressInfo } from "net";
 import { dnsTypeToString } from "./dns-string-utils";
 import { DNSLabelCoder, NonCompressionLabelCoder } from "./DNSLabelCoder";

--- a/src/coder/records/NSECRecord.ts
+++ b/src/coder/records/NSECRecord.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import deepEqual from "fast-deep-equal";
+import {isDeepStrictEqual as deepEqual} from "util";
 import { dnsLowerCase } from "../../util/dns-equal";
 import { DNSLabelCoder } from "../DNSLabelCoder";
 import { DecodedData, RType } from "../DNSPacket";

--- a/src/coder/records/OPTRecord.ts
+++ b/src/coder/records/OPTRecord.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import deepEquals from "fast-deep-equal";
+import {isDeepStrictEqual as deepEquals} from "util";
 import { DNSLabelCoder } from "../DNSLabelCoder";
 import { DecodedData, RType } from "../DNSPacket";
 import { RecordRepresentation, ResourceRecord } from "../ResourceRecord";


### PR DESCRIPTION
Remove the `fast-deep-equal` dependency, replacing it with Node's built-in `util` library.