### PR TITLE
fix: handle IPv4 address transitions gracefully on dynamic networks

### DIFF
--- a/src/MDNSServer.spec.ts
+++ b/src/MDNSServer.spec.ts
@@ -1,6 +1,65 @@
 import { MDNSServer, SendResultFailedRatio } from "./MDNSServer";
+import { NetworkUpdate } from "./NetworkManager";
 
 describe(MDNSServer, () => {
+  describe("handleUpdatedNetworkInterfaces - IPv4 transitions", () => {
+    let server: MDNSServer;
+
+    beforeEach(() => {
+      // Create server without binding - no real sockets are opened
+      server = new MDNSServer({ handleQuery: () => {}, handleResponse: () => {} });
+    });
+
+    afterEach(() => {
+      server.getNetworkManager().removeAllListeners();
+    });
+
+    it("should handle IPv4 appearing on interface (undefined → address) without crashing", () => {
+      const update: NetworkUpdate = {
+        changes: [{
+          name: "en0",
+          outdatedIpv4: undefined,
+          updatedIpv4: "192.168.1.100",
+        }],
+      };
+
+      // Should not throw - before fix this hit assert.fail()
+      expect(() => {
+        (server as any).handleUpdatedNetworkInterfaces(update);
+      }).not.toThrow();
+    });
+
+    it("should handle IPv4 disappearing on interface (address → undefined) without crashing", () => {
+      const update: NetworkUpdate = {
+        changes: [{
+          name: "en0",
+          outdatedIpv4: "192.168.1.100",
+          updatedIpv4: undefined,
+        }],
+      };
+
+      // Should not throw - before fix this hit assert.fail()
+      expect(() => {
+        (server as any).handleUpdatedNetworkInterfaces(update);
+      }).not.toThrow();
+    });
+
+    it("should handle both IPv4 undefined (undefined → undefined) without crashing", () => {
+      const update: NetworkUpdate = {
+        changes: [{
+          name: "en0",
+          outdatedIpv4: undefined,
+          updatedIpv4: undefined,
+        }],
+      };
+
+      // No-op case: no IPv4 on either side
+      expect(() => {
+        (server as any).handleUpdatedNetworkInterfaces(update);
+      }).not.toThrow();
+    });
+  });
+
   it("SendResultFailedRatio", () => {
     expect(SendResultFailedRatio([
       { status: "fulfilled", interface: "eth0"},

--- a/src/MDNSServer.ts
+++ b/src/MDNSServer.ts
@@ -686,13 +686,30 @@ export class MDNSServer {
         // Handle IPv4
         let socket = this.sockets.get(change.name);
         if (!change.outdatedIpv4 && change.updatedIpv4) {
-          // this does currently not happen, as we exclude ipv6 only interfaces
-          // thus such a change would be happening through the ADDED array
-          assert.fail("Reached illegal state! IPv4 address changed from undefined to defined!");
+          // On dynamic networks (e.g., Starlink, cellular), an interface may gain
+          // an IPv4 address after initially appearing as IPv6-only. Handle gracefully
+          // by treating it like a new interface addition for IPv4.
+          debug("IPv4 address appeared on changed interface %s (was undefined, now %s). Adding membership.", change.name, change.updatedIpv4);
+          if (socket) {
+            try {
+              socket.addMembership(MDNSServer.MULTICAST_IPV4, change.updatedIpv4);
+              socket.setMulticastInterface(change.updatedIpv4);
+            } catch (error) {
+              debug("Error adding membership for newly appeared IPv4 on %s: %s", change.name, error.message);
+            }
+          }
         } else if (change.outdatedIpv4 && !change.updatedIpv4) {
-          // this does currently not happen, as we exclude ipv6 only interfaces
-          // thus such a change would be happening through the REMOVED array
-          assert.fail("Reached illegal state! IPV4 address change from defined to undefined!");
+          // On dynamic networks, an interface may lose its IPv4 address temporarily
+          // (e.g., Starlink network flap, DHCP lease expiry). Handle gracefully by
+          // dropping the old membership instead of crashing.
+          debug("IPv4 address disappeared on changed interface %s (was %s, now undefined). Dropping membership.", change.name, change.outdatedIpv4);
+          if (socket) {
+            try {
+              socket.dropMembership(MDNSServer.MULTICAST_IPV4, change.outdatedIpv4);
+            } catch (error) {
+              debug("Error dropping membership for disappeared IPv4 on %s: %s", change.name, error.message);
+            }
+          }
         } else if (socket && change.outdatedIpv4 && change.updatedIpv4) {
           try {
             socket!.dropMembership(MDNSServer.MULTICAST_IPV4, change.outdatedIpv4);


### PR DESCRIPTION
## Problem

On dynamic networks (Starlink, cellular hotspots, DHCP environments), network interfaces can temporarily lose or gain IPv4 addresses. When this happens, `MDNSServer.ts` hits `assert.fail()` at lines 691/695, crashing the entire Node.js process.

The comments in the code acknowledge these states "do not currently happen" — but they do on real-world dynamic networks.

### Error
```
AssertionError [ERR_ASSERTION]: Reached illegal state! IPV4 address change from defined to undefined!
    at MDNSServer.handleUpdatedNetworkInterfaces (MDNSServer.ts:695)
```

### Impact
This crashes any downstream consumer that depends on `@homebridge/ciao`, including OpenClaw's gateway process via its mDNS dependency chain.

## Fix

Replace `assert.fail()` with graceful handling:
- **IPv4 appears** (undefined → defined): Add multicast membership, log via `debug()`
- **IPv4 disappears** (defined → undefined): Drop multicast membership, log via `debug()`

Both cases continue operating instead of crashing the process.

## Testing

Tested on a Mac Mini connected via Starlink satellite internet, which regularly causes network interface flaps during dish repositioning. Before this fix, the gateway would crash ~2-3 times daily. After the fix, transitions are handled silently.